### PR TITLE
MINOR CHANGE - Add a check for CLI execution

### DIFF
--- a/code/ControllerPolicyRequestFilter.php
+++ b/code/ControllerPolicyRequestFilter.php
@@ -55,9 +55,11 @@ class ControllerPolicyRequestFilter implements RequestFilter {
 	 */
 	public function postRequest(SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model) {
 
-		// Ingore by regexes.
-		if ($this->isIgnoredDomain($_SERVER['HTTP_HOST'])) {
-			return true;
+		if (!Director::is_cli() && isset($_SERVER['HTTP_HOST'])) {
+			// Ignore by regexes.
+			if ($this->isIgnoredDomain($_SERVER['HTTP_HOST'])) {
+				return true;
+			}
 		}
 
 		foreach ($this->requestedPolicies as $requestedPolicy) {


### PR DESCRIPTION
Because php5-cli does not have HTTP_HOST set, this causes PHP error of type warning
