### PR TITLE
NEW Work with new HTTPCacheControl class (1.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,8 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.4
-      env: DB=PGSQL CORE_RELEASE=3.4
-    - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=3.5
     - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.6
+      env: DB=PGSQL CORE_RELEASE=3
     - php: 7.0
       env: DB=MYSQL CORE_RELEASE=3
     - php: 7.1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Build Status](https://travis-ci.org/silverstripe/silverstripe-controllerpolicy.svg)](https://travis-ci.org/silverstripe/silverstripe-controllerpolicy)
 
+**This module is deprecated for usage with SilverStripe 3.7+**.
+The [HTTPCacheControl API](https://docs.silverstripe.org/en/3/developer_guides/performance/http_cache_headers/)
+in SilverStripe Framework provides a more high-level abstraction of caching behaviour. 
+
+## Overview
+
 This module has been designed to provide the ability to configure response policies that apply per specific
 Controller.
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ Let's say we want to apply a caching header of max-age 300 to the HomePage only.
 Using this policy is done via your project-specific **config.yml**. We configure the pseudo-singleton via
 Dependency Injection and apply it directly to `HomePage_Controller`:
 
-	Injector:
-	  StandardCachingPolicy:
-		class: CachingPolicy
-		properties:
-		  cacheAge: 300
-	HomePage_Controller:
-	  dependencies:
-		Policies: '%$StandardCachingPolicy'
+```yml
+Injector:
+  StandardCachingPolicy:
+    class: CachingPolicy
+    properties:
+      cacheAge: 300
+HomePage_Controller:
+  dependencies:
+    Policies: '%$StandardCachingPolicy'
+```
 
 Every policy will set headers on top of the default framework's `HTTP::add_cache_headers`, which is exactly what we
 want. This allows us to for example customise the `Vary` headers per policy, which were previously hardcoded.
@@ -40,9 +42,11 @@ want. This allows us to for example customise the `Vary` headers per policy, whi
 
 If you wish to exclude some domains from the policies completely, you can do the following:
 
-	ControllerPolicyRequestFilter:
-	  ignoreDomainRegexes:
-		- '/.*\.uat.server.com$/'
+```yml
+ControllerPolicyRequestFilter:
+  ignoreDomainRegexes:
+    - '/.*\.uat.server.com$/'
+```
 
 This could be useful for example if you wish to disable caching on test servers, or if you are doing aggressive caching
 and want your editors to see changed resources immediately.
@@ -51,12 +55,14 @@ and want your editors to see changed resources immediately.
 
 _CachingPolicy_ also allows customisation of _Vary_ headers through the config system:
 
-	Injector:
-	  StandardCachingPolicy:
-		class: CachingPolicy
-		properties:
-		  cacheAge: 300
-		  vary: 'Cookie, X-Forwarded-Protocol, Accept-Language'
+```yml
+Injector:
+  StandardCachingPolicy:
+    class: CachingPolicy
+    properties:
+      cacheAge: 300
+      vary: 'Cookie, X-Forwarded-Protocol, Accept-Language'
+```
 
 Any URL which content depends on an impulse from the visitor should use Vary header to encode this dependency, otherwise caches might serve wrong content to the wrong user (possibly even confidential data!).
 
@@ -78,9 +84,11 @@ If you apply a policy to a certain `Controller` it will apply to all inheriting 
 
 You can break that chain easily by applying a policy to the inheriting controller as long as you are not using arrays for configuration (which you ordinarily wouldn't be - but see the "Complex policies" chapter below):
 
-	FooPage_Controller:
- 	  dependencies:
-	    Policies: '%$NoopPolicy'
+```yml
+FooPage_Controller:
+  dependencies:
+    Policies: '%$NoopPolicy'
+```
 
 The `NoopPolicy` is a policy that does nothing, so you can use it to "disable" certain controllers. This is useful for example for GET-based multi-step forms (via the [silverstripe-multiform](https://github.com/silverstripe/silverstripe-multiform)) module, where steps are traversed via GET requests, and URIs don't differ - hence preventing your from actually progressing through the form.
 
@@ -91,17 +99,19 @@ Note that you can use any other policy to override the existing one - it doesn't
 Here is an example of how to implement CMS capability to override the max-age per specific page. In your config file
 put the following statements:
 
-	Injector:
-	  GeneralCachingPolicy:
-		class: CachingPolicy
-		properties:
-		  cacheAge: 900
-	Page_Controller:
-	  dependencies:
-		Policies: '%$GeneralCachingPolicy'
-	Page:
-	  extensions:
-		- PageControlledPolicy
+```yml
+Injector:
+  GeneralCachingPolicy:
+    class: CachingPolicy
+    properties:
+      cacheAge: 900
+Page_Controller:
+  dependencies:
+    Policies: '%$GeneralCachingPolicy'
+Page:
+  extensions:
+    - PageControlledPolicy
+```
 
 Here, applying the `PageControlledPolicy` extension to the `Page` results in a new "MaxAge" field being written into the
 DB, and a new tab available ("Caching") which lets the ADMIN user tweak the cache max-age header (denominated in
@@ -116,29 +126,31 @@ In this example we want to configure a global setting consisting of two policies
 second to configure custom header. Then we want to add more specific policy for the home page max-age, while keeping the
 custom header. Here is how to achieve this using the config system:
 
-	Injector:
-	  ShortCachingPolicy:
-		class: CachingPolicy
-		properties:
-		  cacheAge: 300
-	  LongCachingPolicy:
-		class: CachingPolicy
-		properties:
-		  cacheAge: 3600
-	  CustomPolicy:
-		 class: CustomHeaderPolicy
-		 properties:
-		   headers:
-			 Custom-Header: "Hello"
-	HomePage_Controller:
-	  dependencies:
-		Policies:
-		  - '%$LongCachingPolicy'
-	Page_Controller:
-	  dependencies:
-		Policies:
-		  - '%$ShortCachingPolicy'
-		  - '%$CustomPolicy'
+```
+Injector:
+  ShortCachingPolicy:
+    class: CachingPolicy
+  properties:
+    cacheAge: 300
+  LongCachingPolicy:
+    class: CachingPolicy
+    properties:
+      cacheAge: 3600
+  CustomPolicy:
+   class: CustomHeaderPolicy
+   properties:
+     headers:
+     Custom-Header: "Hello"
+HomePage_Controller:
+  dependencies:
+    Policies:
+      - '%$LongCachingPolicy'
+Page_Controller:
+  dependencies:
+    Policies:
+      - '%$ShortCachingPolicy'
+      - '%$CustomPolicy'
+```
 
 Outcome of the array merging for the home page will be as follows:
 

--- a/code/ControllerPolicyApplicator.php
+++ b/code/ControllerPolicyApplicator.php
@@ -10,7 +10,7 @@
 class ControllerPolicyApplicator extends Extension
 {
     /**
-     * @var RequestFilter
+     * @var ControllerPolicyRequestFilter
      */
     private $requestFilter;
 
@@ -20,7 +20,7 @@ class ControllerPolicyApplicator extends Extension
     protected $policies = array();
 
     /**
-     * @param RequestFilter $filter
+     * @param ControllerPolicyRequestFilter $filter
      */
     public function setRequestFilter($filter)
     {

--- a/code/ControllerPolicyRequestFilter.php
+++ b/code/ControllerPolicyRequestFilter.php
@@ -40,6 +40,9 @@ class ControllerPolicyRequestFilter implements RequestFilter
 
     /**
      * Add a policy tuple.
+     *
+     * @param object $originator
+     * @param ControllerPolicy $policy
      */
     public function requestPolicy($originator, $policy)
     {
@@ -75,7 +78,9 @@ class ControllerPolicyRequestFilter implements RequestFilter
         }
 
         foreach ($this->requestedPolicies as $requestedPolicy) {
-            $requestedPolicy['policy']->applyToResponse(
+            /** @var ControllerPolicy $controllerPolicy */
+            $controllerPolicy = $requestedPolicy['policy'];
+            $controllerPolicy->applyToResponse(
                 $requestedPolicy['originator'],
                 $request,
                 $response,

--- a/code/PageControlledPolicy.php
+++ b/code/PageControlledPolicy.php
@@ -3,6 +3,9 @@
  * This extension leverages the CachingPolicy's ability to customise the max-age per originator.
  * The configuration option is surfaced to the CMS UI. The extension needs to be added
  * to the object related to the policed controller.
+ *
+ * @property string MaxAge
+ * @property PageControlledPolicy $owner
  */
 class PageControlledPolicy extends DataExtension
 {
@@ -16,13 +19,15 @@ class PageControlledPolicy extends DataExtension
     /**
      * Extension point for the CachingPolicy.
      *
-     * @param int $cacheAge
+     * @param int $cacheAge Default cache age
+     * @return int|null Preferred cache age, or null if no cache age specified
      */
     public function getCacheAge($cacheAge)
     {
-        if ($this->owner->MaxAge!='') {
-            return (int)($this->owner->MaxAge*60);
+        if ($this->owner->MaxAge != '') {
+            return (int)($this->owner->MaxAge * 60);
         }
+        return null;
     }
 
     /**

--- a/code/policies/BackwardsCompatibleCachingPolicy.php
+++ b/code/policies/BackwardsCompatibleCachingPolicy.php
@@ -59,9 +59,11 @@ class BackwardsCompatibleCachingPolicy extends HTTP implements ControllerPolicy
             $response->addHeader('Vary', $vary);
         }
 
-        // Ensure we override any existing cache policy
+        // Ensure we override any existing cache policy, and enable parent
         $response->removeHeader('Cache-Control');
-
+        Config::nest();
+        Config::inst()->remove('HTTP', 'disable_http_cache');
         static::add_cache_headers($response);
+        Config::unnest();
     }
 }

--- a/code/policies/BackwardsCompatibleCachingPolicy.php
+++ b/code/policies/BackwardsCompatibleCachingPolicy.php
@@ -49,6 +49,8 @@ class BackwardsCompatibleCachingPolicy extends HTTP implements ControllerPolicy
      */
     public function applyToResponse($originator, SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model)
     {
+        Deprecation::notice("4.0.0", "Use HTTPCacheControl::singleton() instead of controllerpolicy");
+
         if ($this->cacheAge > 0) {
             HTTPCacheControl::singleton()->setMaxAge($this->cacheAge);
         }

--- a/code/policies/BackwardsCompatibleCachingPolicy.php
+++ b/code/policies/BackwardsCompatibleCachingPolicy.php
@@ -59,6 +59,9 @@ class BackwardsCompatibleCachingPolicy extends HTTP implements ControllerPolicy
             $response->addHeader('Vary', $vary);
         }
 
+        // Ensure we override any existing cache policy
+        $response->removeHeader('Cache-Control');
+
         static::add_cache_headers($response);
     }
 }

--- a/code/policies/CachingPolicy.php
+++ b/code/policies/CachingPolicy.php
@@ -36,7 +36,7 @@ class CachingPolicy extends HTTP implements ControllerPolicy
         $cacheAge = $this->cacheAge;
         $vary = $this->vary;
 
-                // Allow overriding max-age from the object hooked up to the policed controller.
+        // Allow overriding max-age from the object hooked up to the policed controller.
         if ($originator->hasMethod('getCacheAge')) {
             /** @var PageControlledPolicy $originator */
             $extendedCacheAge = $originator->getCacheAge($cacheAge);

--- a/code/policies/CachingPolicy.php
+++ b/code/policies/CachingPolicy.php
@@ -53,72 +53,76 @@ class CachingPolicy extends HTTP implements ControllerPolicy
             }
         }
 
+        $cacheControlHeaders = Config::inst()->get(__CLASS__, 'cache_control');
+        if (!empty($cacheControlHeaders)) {
+            HTTPCacheControl::singleton()->setDirectivesFromArray($cacheControlHeaders);
+        }
+
         if ($cacheAge > 0) {
-            // Note: must-revalidate means that the cache must revalidate AFTER the entry has gone stale.
-            $responseHeaders["Cache-Control"] = "max-age=" . $cacheAge . ", must-revalidate, no-transform";
+            HTTPCacheControl::singleton()->setMaxAge($cacheAge);
+        }
 
-            // Set empty pragma to avoid PHP's session_cache_limiter adding conflicting caching information,
-            // defaulting to "nocache" on most PHP configurations (see http://php.net/session_cache_limiter).
-            // Since it's a deprecated HTTP 1.0 option, all modern HTTP clients and proxies should
-            // prefer the caching information indicated through the "Cache-Control" header.
-            $responseHeaders["Pragma"] = "";
-
-            $responseHeaders['Vary'] = $vary;
-
-            // Find out when the URI was last modified. Allows customisation, but fall back HTTP timestamp collector.
-            if ($originator->hasMethod('getModificationTimestamp')) {
-                $timestamp = $originator->getModificationTimestamp();
+        if ($vary && strlen($vary)) {
+            // split the current vary header into it's parts and merge it with the config settings
+            // to create a list of unique vary values
+            if ($request->getHeader('Vary')) {
+                $currentVary = explode(',', $request->getHeader('Vary'));
             } else {
-                $timestamp = HTTP::$modification_date;
+                $currentVary = array();
             }
+            $vary = explode(',', $vary);
+            $vary = array_merge($currentVary, $vary);
+            $vary = array_map('trim', $vary);
+            $vary = array_unique($vary);
+            $vary = implode(', ', $vary);
+            $responseHeaders['Vary'] = $vary;
+        }
 
-            if ($timestamp) {
-                $responseHeaders["Last-Modified"] = self::gmt_date($timestamp);
+        // Find out when the URI was last modified. Allows customisation, but fall back HTTP timestamp collector.
+        if ($originator->hasMethod('getModificationTimestamp')) {
+            $timestamp = $originator->getModificationTimestamp();
+        } else {
+            $timestamp = HTTP::$modification_date;
+        }
 
-                // Chrome ignores Varies when redirecting back (http://code.google.com/p/chromium/issues/detail?id=79758)
-                // which means that if you log out, you get redirected back to a page which Chrome then checks against
-                // last-modified (which passes, getting a 304)
-                // when it shouldn't be trying to use that page at all because it's the "logged in" version.
-                // By also using and etag that includes both the modification date and all the varies
-                // values which we also check against we can catch this and not return a 304
-                $etagParts = array($timestamp, serialize($_COOKIE));
-                $etagParts[] = Director::is_https() ? 'https' : 'http';
-                if (isset($_SERVER['HTTP_USER_AGENT'])) {
-                    $etagParts[] = $_SERVER['HTTP_USER_AGENT'];
-                }
-                if (isset($_SERVER['HTTP_ACCEPT'])) {
-                    $etagParts[] = $_SERVER['HTTP_ACCEPT'];
-                }
+        if ($timestamp) {
+            $responseHeaders["Last-Modified"] = self::gmt_date($timestamp);
+        }
 
-                $etag = sha1(implode(':', $etagParts));
+        // if we can store the cache responses we should generate and send etags
+        if (!HTTPCacheControl::singleton()->hasDirective('no-store')) {
+            // Chrome ignores Varies when redirecting back (http://code.google.com/p/chromium/issues/detail?id=79758)
+            // which means that if you log out, you get redirected back to a page which Chrome then checks against
+            // last-modified (which passes, getting a 304)
+            // when it shouldn't be trying to use that page at all because it's the "logged in" version.
+            // By also using and etag that includes both the modification date and all the varies
+            // values which we also check against we can catch this and not return a 304
+            $etag = self::generateETag($response);
+
+            if ($etag) {
                 $responseHeaders['ETag'] = $etag;
 
                 // 304 response detection
-                if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
-                    $ifModifiedSince = strtotime(stripslashes($_SERVER['HTTP_IF_MODIFIED_SINCE']));
-
+                if (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
                     // As above, only 304 if the last request had all the same varies values
                     // (or the etag isn't passed as part of the request - but with chrome it always is)
-                    $matchesEtag = !isset($_SERVER['HTTP_IF_NONE_MATCH']) || $_SERVER['HTTP_IF_NONE_MATCH'] == $etag;
+                    $matchesEtag = $_SERVER['HTTP_IF_NONE_MATCH'] == $etag;
 
-                    if ($ifModifiedSince >= $timestamp && $matchesEtag) {
+                    if ($matchesEtag) {
                         $response->setStatusCode(304);
                         $response->setBody('');
                     }
                 }
-
-                $expires = time() + $cacheAge;
-                $responseHeaders['Expires'] = self::gmt_date($expires);
             }
         }
 
-        if (self::$etag) {
-            $responseHeaders['ETag'] = self::$etag;
-        }
+        $expires = time() + HTTPCacheControl::singleton()->getDirective('max-age');
+        $responseHeaders["Expires"] = self::gmt_date($expires);
 
         // Now that we've generated them, either output them or attach them to the SS_HTTPResponse as appropriate
         foreach ($responseHeaders as $k => $v) {
             $response->addHeader($k, $v);
         }
+        HTTPCacheControl::singleton()->applyToResponse($response);
     }
 }

--- a/code/policies/CachingPolicy.php
+++ b/code/policies/CachingPolicy.php
@@ -36,7 +36,7 @@ class CachingPolicy extends HTTP implements ControllerPolicy
         $cacheAge = $this->cacheAge;
         $vary = $this->vary;
 
-        // Allow overriding max-age from the object hooked up to the policed controller.
+                // Allow overriding max-age from the object hooked up to the policed controller.
         if ($originator->hasMethod('getCacheAge')) {
             /** @var PageControlledPolicy $originator */
             $extendedCacheAge = $originator->getCacheAge($cacheAge);
@@ -53,10 +53,8 @@ class CachingPolicy extends HTTP implements ControllerPolicy
             }
         }
 
-        $cacheControlHeaders = Config::inst()->get(__CLASS__, 'cache_control');
-        if (!empty($cacheControlHeaders)) {
-            HTTPCacheControl::singleton()->setDirectivesFromArray($cacheControlHeaders);
-        }
+        // Enable caching via core APIs
+        HTTPCacheControl::singleton()->enableCache();
 
         if ($cacheAge > 0) {
             HTTPCacheControl::singleton()->setMaxAge($cacheAge);

--- a/code/policies/CachingPolicy.php
+++ b/code/policies/CachingPolicy.php
@@ -38,6 +38,7 @@ class CachingPolicy extends HTTP implements ControllerPolicy
 
         // Allow overriding max-age from the object hooked up to the policed controller.
         if ($originator->hasMethod('getCacheAge')) {
+            /** @var PageControlledPolicy $originator */
             $extendedCacheAge = $originator->getCacheAge($cacheAge);
             if ($extendedCacheAge !== null) {
                 $cacheAge = $extendedCacheAge;

--- a/code/policies/NoopPolicy.php
+++ b/code/policies/NoopPolicy.php
@@ -12,6 +12,6 @@ class NoopPolicy implements ControllerPolicy
      */
     public function applyToResponse($originator, SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model)
     {
-        return true;
+        // no op
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "~3.1"
+        "silverstripe/framework": "~3.7"
     },
     "extra": {
         "branch-alias": {

--- a/tests/CachingPolicyTest.php
+++ b/tests/CachingPolicyTest.php
@@ -61,11 +61,9 @@ class CachingPolicyTest extends FunctionalTest
         $directives = explode(',', $response->getHeader('Cache-Control'));
         $directives = array_map('trim', $directives);
 
-        $this->assertCount(4, $directives);
+        $this->assertCount(2, $directives);
         $this->assertContains('max-age=999', $directives);
         $this->assertContains('must-revalidate', $directives);
-        $this->assertContains('no-cache', $directives);
-        $this->assertContains('no-store', $directives);
 
         $this->assertEquals(
             'X-EyeColour',
@@ -85,11 +83,9 @@ class CachingPolicyTest extends FunctionalTest
         $directives = explode(',', $response->getHeader('Cache-Control'));
         $directives = array_map('trim', $directives);
 
-        $this->assertCount(4, $directives);
+        $this->assertCount(2, $directives);
         $this->assertContains('max-age=1001', $directives);
         $this->assertContains('must-revalidate', $directives);
-        $this->assertContains('no-cache', $directives);
-        $this->assertContains('no-store', $directives);
 
         $this->assertEquals(
             'X-HeightWeight',

--- a/tests/CachingPolicyTest.php
+++ b/tests/CachingPolicyTest.php
@@ -58,11 +58,14 @@ class CachingPolicyTest extends FunctionalTest
             'CachingPolicy_Controller/test'
         );
 
-        $this->assertEquals(
-            $response->getHeader('Cache-Control'),
-            'max-age=999, must-revalidate, no-transform',
-            'Header appears as configured'
-        );
+        $directives = explode(',', $response->getHeader('Cache-Control'));
+        $directives = array_map('trim', $directives);
+
+        $this->assertCount(3, $directives);
+        $this->assertContains('max-age=999', $directives);
+        $this->assertContains('must-revalidate', $directives);
+        $this->assertContains('no-cache', $directives);
+
         $this->assertEquals(
             $response->getHeader('Vary'),
             'X-EyeColour',
@@ -78,11 +81,14 @@ class CachingPolicyTest extends FunctionalTest
             'CallbackCachingPolicy_Controller/test'
         );
 
-        $this->assertEquals(
-            $response->getHeader('Cache-Control'),
-            'max-age=1001, must-revalidate, no-transform',
-            'Controller\'s getCacheAge() overrides the configuration'
-        );
+        $directives = explode(',', $response->getHeader('Cache-Control'));
+        $directives = array_map('trim', $directives);
+
+        $this->assertCount(3, $directives);
+        $this->assertContains('max-age=1001', $directives);
+        $this->assertContains('must-revalidate', $directives);
+        $this->assertContains('no-cache', $directives);
+
         $this->assertEquals(
             $response->getHeader('Vary'),
             'X-HeightWeight',

--- a/tests/CachingPolicyTest.php
+++ b/tests/CachingPolicyTest.php
@@ -61,14 +61,15 @@ class CachingPolicyTest extends FunctionalTest
         $directives = explode(',', $response->getHeader('Cache-Control'));
         $directives = array_map('trim', $directives);
 
-        $this->assertCount(3, $directives);
+        $this->assertCount(4, $directives);
         $this->assertContains('max-age=999', $directives);
         $this->assertContains('must-revalidate', $directives);
         $this->assertContains('no-cache', $directives);
+        $this->assertContains('no-store', $directives);
 
         $this->assertEquals(
-            $response->getHeader('Vary'),
             'X-EyeColour',
+            $response->getHeader('Vary'),
             'Header appears as configured'
         );
     }
@@ -84,14 +85,15 @@ class CachingPolicyTest extends FunctionalTest
         $directives = explode(',', $response->getHeader('Cache-Control'));
         $directives = array_map('trim', $directives);
 
-        $this->assertCount(3, $directives);
+        $this->assertCount(4, $directives);
         $this->assertContains('max-age=1001', $directives);
         $this->assertContains('must-revalidate', $directives);
         $this->assertContains('no-cache', $directives);
+        $this->assertContains('no-store', $directives);
 
         $this->assertEquals(
-            $response->getHeader('Vary'),
             'X-HeightWeight',
+            $response->getHeader('Vary'),
             'Controller\'s getVary() overrides the configuration'
         );
         $this->assertEquals(


### PR DESCRIPTION
These are the "face value" changes to controller policy which make use of the proposed API from https://github.com/silverstripe/silverstripe-framework/pull/8086

I've updated `BackwardsCompatibleCachingPolicy` to better reflect current core behaviour including merging `Vary` headers and ETag fixes.